### PR TITLE
Adjust comment blocks in css_painting_api

### DIFF
--- a/files/en-us/web/api/css_painting_api/index.md
+++ b/files/en-us/web/api/css_painting_api/index.md
@@ -55,15 +55,16 @@ registerPaint(
     }
 
     /*
-     use this function to retrieve any custom properties (or regular properties, such as 'height')
-     defined for the element, return them in the specified array
-  */
+      use this function to retrieve any custom properties
+      (or regular properties, such as 'height') defined for the element,
+      return them in the specified array
+    */
     static get inputProperties() {
       return ["--boxColor", "--widthSubtractor"];
     }
 
     paint(ctx, size, props) {
-      /*
+    /*
        ctx -> drawing context
        size -> paintSize: width and height
        props -> properties: get() method


### PR DESCRIPTION
In page https://developer.mozilla.org/en-US/docs/Web/API/CSS_Painting_API, the JS code comment blocks were a little off especially when viewed on Chrome or a Chromium browser. Requesting these adjustments to fix the spacing of the comments. Thanks!

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
